### PR TITLE
Update for openshift 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   
 Prometheus Alertmanager - sends Prometheus alerts to HP OMi (Operation Manager i)  
 
-Settings.ini setting as post-url, assignee group
+Settings.ini setting as post-url, assignee group and OpenShift Version (3 or 4)
 
 template.xml is needed for converting json to omi xml output
 
@@ -33,4 +33,4 @@ changes needed for alertmanager:
     url: http://alert2omi.prometheus.svc:8080/webhook
 ```
 
-Tested on OpenShift 3.6 - 3.7
+Tested on OpenShift 3.6 - 3.7 and 4.1 - 4.3

--- a/app.py
+++ b/app.py
@@ -26,7 +26,8 @@ try:
     ini_subcategory = config.get('global', 'subcategory')
     ini_affectedCI = config.get('global','affectedCI')
     verbose = config.get('global','verbose')
-    print('Configuration settings:\n\nposturl: %s\ncategory: %s\naffectedCI: %s\nverbose: %s\n\n' % (post_url,ini_category,ini_affectedCI,verbose))
+    openshiftversion = config.get('global','openshiftversion')
+    print('Configuration settings:\n\nposturl: %s\nopenshiftversion: %s\ncategory: %s\naffectedCI: %s\nverbose: %s\n\n' % (post_url,openshiftversion,ini_category,ini_affectedCI,verbose))
 
 except Exception as ex:
     print('Something is wrong with config: {}'.format(ex))
@@ -55,11 +56,29 @@ def webhook():
         if verbose:
           print("Incoming JSON:\n%s\n" % alert)
 
+        if openshiftversion == "4":
+
+            if "hostname" in alert['commonLabels']:
+                node = alert['commonLabels']['hostname']
+            else:
+                node = "cluster"
+            
+            title=alert['commonLabels']['alertname']
+            description=alert['commonAnnotations']['message']
+            severity=alert['commonLabels']['severity']
+
+        elif openshiftversion == "3":
+
+            title=alert['commonAnnotations']['summary'],
+            description=alert['commonAnnotations']['description'],
+            severity=alert['commonAnnotations']['severity'],
+            node=alert['commonLabels']['kubernetes_io_hostname'],
+
         omi = render_template('template.xml',
-                              title=alert['commonAnnotations']['summary'],
-                              description=alert['commonAnnotations']['description'],
-                              severity=alert['commonAnnotations']['severity'],
-                              node=alert['commonLabels']['kubernetes_io_hostname'],
+                              title=title,
+                              description=description,
+                              severity=severity,
+                              node=node,
                               subcategory=ini_subcategory,
                               category=ini_category,
                               affectedCI=ini_affectedCI

--- a/settings.ini
+++ b/settings.ini
@@ -4,3 +4,4 @@ category = openshift
 subcategory = infrastructure
 affectedCI = OPENSHIFT (PRODUKT)
 verbose = true
+openshiftversion = 4


### PR DESCRIPTION
This will fix #2 

Here is a copy of the message send to alert2omi. I created a swich for openshift 3 and 4 so both versions are compatible
```
{
  'externalURL': 'https://alertmanager-main-openshift-monitoring.apps.clustername.cluster.local',
  'status': 'firing',
  'groupLabels': {},
  'commonAnnotations': {
    'message': 'This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n"DeadMansSnitch" integration in PagerDuty.\n'
   }, 
  'version': '4', 
  'receiver': 'alert2omi', 
  'alerts': 
    [
      {
       'status': 'firing', 
       'annotations': {
         'message': 'This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n"DeadMansSnitch" integration in PagerDuty.\n'
          },
         'startsAt': '2020-04-19T23:20:30.163677339Z', 
         'generatorURL': 'https://prometheus-k8s-openshift-monitoring.apps.clustername.cluster.local/graph?g0.expr=vector%281%29&g0.tab=1',
         'labels': {
           'alertname': 'Watchdog', 
           'severity': 'none', 
           'prometheus': 'openshift-monitoring/k8s'
         },
        'fingerprint': 'e25963d69425c836', 
        'endsAt': '0001-01-01T00:00:00Z'
      }
    ], 
  'commonLabels': {
    'alertname': 'Watchdog', 
    'severity': 'none',
    'prometheus': 'openshift-monitoring/k8s'
  },
  'groupKey': '{}:{}'
}
```